### PR TITLE
s/frobenius endomorphism/conductor/

### DIFF
--- a/poly.tex
+++ b/poly.tex
@@ -1693,7 +1693,7 @@ eventually forms a cycle, the \emph{crater} of a volcano.
 
 \begin{exercice}
   Prove that the height of a volcano of $ℓ$-isogenies is $v_ℓ(f_π)$,
-  the $ℓ$-adic valuation of the Frobenius endomorphism.
+  the $ℓ$-adic valuation of the conductor of $ℤ[π]$.
 \end{exercice}
 
 \begin{exercice}


### PR DESCRIPTION
Minor change : f_\pi is the conductor of ZZ[pi].