### PR TITLE
typo for bilinear form

### DIFF
--- a/poly.tex
+++ b/poly.tex
@@ -1255,7 +1255,7 @@ think of vector spaces over a field instead.
   A bilinear form is said to be \emph{non-degenerate} if:
   \begin{itemize}
   \item $e(P,Q)=0$ for all $P$ implies $Q=0$, and
-  \item $e(P,Q)=0$ for all $Q$ implies $Q=0$.
+  \item $e(P,Q)=0$ for all $Q$ implies $P=0$.
   \end{itemize}
 
   A bilinear form is said to be \emph{alternating} if $M_1=M_2$ and


### PR DESCRIPTION
  A bilinear form is said to be _non-degenerate_ if:
  - $e(P,Q)=0$ for all $P$ implies $Q=0$, and
  - $e(P,Q)=0$ for all $Q$ implies $Q=0$.

The lattter one should be $P=0$.